### PR TITLE
default to process.cwd() instead of __dirname

### DIFF
--- a/swank.js
+++ b/swank.js
@@ -51,7 +51,7 @@ var serve = function(opts, callback){
   }
 
   //defaults
-  var dir  = opts.path || __dirname; //default to CWD
+  var dir  = opts.path || process.cwd(); //default to CWD
   var port = opts.port || process.env.PORT || 8000;
   var host = (os.hostname()||'localhost');
   var log  = (opts.log === undefined ? (opts.console ? true : false) : opts.log);


### PR DESCRIPTION
`__dirname` returns the path to the script itself (e.g. `/usr/local/lib/node_modules/swank`) and not the current working dir.